### PR TITLE
Add rockspec for 3.1.5

### DIFF
--- a/rockspecs/bump-3.1.5-1.rockspec
+++ b/rockspecs/bump-3.1.5-1.rockspec
@@ -1,0 +1,26 @@
+package = "bump"
+version = "3.1.5-1"
+source = {
+   url = "git://github.com/kikito/bump.lua",
+   tag = "v3.1.5",
+   dir = "bump.lua"
+}
+description = {
+   summary = "A collision detection library for Lua",
+   detailed = [[
+   Bump is a library for for resolving collisions between axis-aligned 
+   bounding boxes (AABBs). It is ideal for simple games that require 
+   non-realistic physics.
+   ]],
+   homepage = "http://github.com/kikito/bump.lua",
+   license = "MIT"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+build = {
+   type = "builtin",
+   modules = {
+      bump = "bump.lua"
+   }
+}


### PR DESCRIPTION
Adding so bump.lua can be managed with [LÖVERocks](https://github.com/Alloyed/loverocks).
To avoid PR spam, I'll just mention that I have similar rockspecs in for tween.lua, gamera, and anim8 in this [test repo](https://github.com/Alloyed/loverocks-repo)
If possible, can you also upload the rockspecs to luarocks.org so it can be used without a custom repository? Thank you.