### PR TITLE
Simplified logic in slide response.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - luarocks install luacov-coveralls
 
 script:
-  - luacheck --no-unused-args --std max+busted *.lua spec
+  - luacheck --no-unused-args --no-max-line-length --std max+busted *.lua spec
   - busted --verbose --coverage
 
 after_success:

--- a/bump.lua
+++ b/bump.lua
@@ -280,19 +280,17 @@ local slide = function(world, col, x,y,w,h, goalX, goalY, filter)
   goalY = goalY or y
 
   local tch, move  = col.touch, col.move
-  local sx, sy     = tch.x, tch.y
   if move.x ~= 0 or move.y ~= 0 then
-    if col.normal.x == 0 then
-      sx = goalX
+    if col.normal.x ~= 0 then
+      goalX = tch.x
     else
-      sy = goalY
+      goalY = tch.y
     end
   end
 
-  col.slide = {x = sx, y = sy}
+  col.slide = {x = goalX, y = goalY}
 
-  x,y          = tch.x, tch.y
-  goalX, goalY = sx, sy
+  x,y = tch.x, tch.y
   local cols, len  = world:project(col.item, x,y,w,h, goalX, goalY, filter)
   return goalX, goalY, cols, len
 end

--- a/spec/responses_spec.lua
+++ b/spec/responses_spec.lua
@@ -51,9 +51,9 @@ describe('bump.responses', function()
             assert.same(touch( 3, 3,2,2, 0,0,8,8), { 3, 8,  0, 1}) -- 5
             assert.same(touch( 7, 3,2,2, 0,0,8,8), { 8, 3,  1, 0}) -- 6
 
-            assert.same(touch(-1, 7,2,2, 0,0,8,8), {-1, 8,  0, 1}) -- 1
-            assert.same(touch( 3, 7,2,2, 0,0,8,8), { 3, 8,  0, 1}) -- 2
-            assert.same(touch( 7, 7,2,2, 0,0,8,8), { 7, 8,  0, 1}) -- 3
+            assert.same(touch(-1, 7,2,2, 0,0,8,8), {-1, 8,  0, 1}) -- 7
+            assert.same(touch( 3, 7,2,2, 0,0,8,8), { 3, 8,  0, 1}) -- 8
+            assert.same(touch( 7, 7,2,2, 0,0,8,8), { 7, 8,  0, 1}) -- 9
 
           end)
         end)


### PR DESCRIPTION
I was going through the bump source code recently and saw an opportunity for a small readability improvement to the slide function. I think removing `sx` and `sy` makes it a tad easier to understand, hopefully you'll agree.

I also added `--no-max-line-length` so that the Travis build would pass. I think luacheck started getting upset about lines longer than 120 character since a commit was last made to this repo.